### PR TITLE
Use typo3/cms-core instead of typo3/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "namelesscoder/typo3-cms-fluid-precompiler",
     "require": {
-        "typo3/cms": "^8.5"
+        "typo3/cms-core": "^8.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since TYPO3 8 you shouldn't require the full core again. Instead just require the single core extensions that you depend on.